### PR TITLE
fix(image_processing): Use blockhash algorithm and slightly increase difference threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ storage/
 
 # Misc
 Notes.txt
+
+# Test images
+false_positives/
+true_positives/


### PR DESCRIPTION
This change makes the bot a lot less chaotic when comparing images and
adds two (ignored by default) tests that allow local testing of image
sets to test for regressions when fine turning these settings in the
future